### PR TITLE
Add push notification debug logging with configurable Settings page

### DIFF
--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -13,7 +13,7 @@ android {
         applicationId "by.bk.bookkeeper.android"
         minSdkVersion 28
         targetSdkVersion 35
-        versionCode 18
+        versionCode 19
         versionName "2.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/mobile/app/src/main/java/by/bk/bookkeeper/android/push/PushListenerService.kt
+++ b/mobile/app/src/main/java/by/bk/bookkeeper/android/push/PushListenerService.kt
@@ -7,23 +7,60 @@ import android.service.notification.StatusBarNotification
 
 class PushListenerService : NotificationListenerService() {
 
+    private val recentNotifications = mutableSetOf<String>()
+    private val cleanupThreshold = 100 // Clean up after this many notifications
+
     override fun onNotificationPosted(sbn: StatusBarNotification) {
         super.onNotificationPosted(sbn)
+
+        val text = sbn.notification.extras?.getString(Notification.EXTRA_TEXT) ?: ""
+
+        // Skip notifications with empty text (Android sometimes posts updates/removals with empty content)
+        if (text.isBlank()) {
+            return
+        }
+
+        // Create a unique key for this notification (package + text + timestamp)
+        val notificationKey = "${sbn.packageName}|${text}|${sbn.postTime}"
+
+        // Skip if we've already processed this exact notification
+        if (recentNotifications.contains(notificationKey)) {
+            return
+        }
+
+        // Add to recent notifications set
+        recentNotifications.add(notificationKey)
+
+        // Clean up old entries if set gets too large
+        if (recentNotifications.size > cleanupThreshold) {
+            recentNotifications.clear()
+        }
+
+        val pushMessage = PushMessage(
+            sbn.packageName ?: "",
+            text,
+            sbn.postTime
+        )
+
+        // Send debug broadcast if enabled
+        if (by.bk.bookkeeper.android.sms.preferences.SharedPreferencesProvider.getDebugPushNotifications()) {
+            sendBroadcast(Intent(ACTION_DEBUG_NOTIFICATION_POSTED).apply {
+                setPackage(packageName)
+                putExtra(PUSH_MESSAGE, pushMessage)
+            })
+        }
+
+        // Send normal broadcast (always)
         sendBroadcast(Intent(ACTION_ON_NOTIFICATION_POSTED).apply {
-            putExtra(
-                PUSH_MESSAGE,
-                PushMessage(
-                    sbn.packageName ?: "",
-                    sbn.notification.extras?.getString(Notification.EXTRA_TEXT) ?: "",
-                    sbn.postTime
-                )
-            )
+            setPackage(packageName)
+            putExtra(PUSH_MESSAGE, pushMessage)
         })
     }
 
     companion object {
         const val PUSH_MESSAGE = "PUSH_MESSAGE"
         const val ACTION_ON_NOTIFICATION_POSTED = "on_notification_posted"
+        const val ACTION_DEBUG_NOTIFICATION_POSTED = "debug_notification_posted"
     }
 
 }

--- a/mobile/app/src/main/java/by/bk/bookkeeper/android/sms/preferences/SharedPreferencesProvider.kt
+++ b/mobile/app/src/main/java/by/bk/bookkeeper/android/sms/preferences/SharedPreferencesProvider.kt
@@ -20,6 +20,7 @@ object SharedPreferencesProvider : IMessagesPreferenceProvider {
     private const val KEY_SERVER_UNPROCESSED_COUNT_RESPONSE = "sms_count_response"
     private const val KEY_ASSOCIATIONS = "associations"
     private const val KEY_SHOULD_PROCESS_SMS = "should_process_sms"
+    private const val KEY_DEBUG_PUSH_NOTIFICATIONS = "debug_push_notifications"
 
     private val gson: Gson by lazy { Gson() }
     private val messagesMapTypeToken = object : TypeToken<HashMap<String, ArrayList<ProcessedMessage>>>() {}.type
@@ -90,6 +91,12 @@ object SharedPreferencesProvider : IMessagesPreferenceProvider {
 
     override fun setShouldProcessReceivedMessages(shouldProcess: Boolean) =
         getSMSPreferences().edit().putBoolean(KEY_SHOULD_PROCESS_SMS, shouldProcess).apply()
+
+    fun getDebugPushNotifications(): Boolean =
+        getSMSPreferences().getBoolean(KEY_DEBUG_PUSH_NOTIFICATIONS, false)
+
+    fun setDebugPushNotifications(enabled: Boolean) =
+        getSMSPreferences().edit().putBoolean(KEY_DEBUG_PUSH_NOTIFICATIONS, enabled).apply()
 
     override fun saveUnprocessedResponseToStorage(response: UnprocessedCountResponse) {
         getSMSPreferences().edit().putString(KEY_SERVER_UNPROCESSED_COUNT_RESPONSE, gson.toJson(response)).apply()

--- a/mobile/app/src/main/java/by/bk/bookkeeper/android/ui/home/AccountingActivity.kt
+++ b/mobile/app/src/main/java/by/bk/bookkeeper/android/ui/home/AccountingActivity.kt
@@ -18,6 +18,7 @@ import by.bk.bookkeeper.android.ui.BaseActivity
 import by.bk.bookkeeper.android.ui.BookkeeperNavigation
 import by.bk.bookkeeper.android.ui.BookkeeperNavigator
 import by.bk.bookkeeper.android.ui.LogoutConfirmationDialog
+import by.bk.bookkeeper.android.ui.settings.SettingsFragment
 import by.bk.bookkeeper.processor.ProcessingService
 import com.google.android.material.navigation.NavigationView
 import com.tbruyelle.rxpermissions2.RxPermissions
@@ -98,6 +99,12 @@ class AccountingActivity : BaseActivity<AccountingActivityViewModel>(),
             }
             R.id.nav_status_messages -> {
                 navigator.showMessagesStatusFragment()
+            }
+            R.id.nav_settings -> {
+                supportFragmentManager.beginTransaction()
+                    .replace(R.id.fragment_container, SettingsFragment())
+                    .commit()
+                supportActionBar?.title = getString(R.string.toolbar_title_settings)
             }
             R.id.nav_logout -> {
                 LogoutConfirmationDialog.show(this)

--- a/mobile/app/src/main/res/menu/activity_accounting_drawer_menu.xml
+++ b/mobile/app/src/main/res/menu/activity_accounting_drawer_menu.xml
@@ -11,6 +11,11 @@
         android:id="@+id/nav_status_messages"
         android:title="@string/menu_messages_status" />
 
+    <item
+        android:id="@+id/nav_settings"
+        android:icon="@drawable/ic_settings"
+        android:title="@string/menu_settings" />
+
     <group
         android:id="@+id/nav_group_other_actions"
         android:checkableBehavior="single">

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
 
     <string name="toolbar_title_accounts">Accounts</string>
     <string name="toolbar_title_messages_status">Messages Status</string>
+    <string name="toolbar_title_settings">Settings</string>
     <string name="hint_paste_template">Paste sms template here (optional)</string>
 
     <string name="msg_service_notification_sms_processing">SMS processing</string>
@@ -74,5 +75,10 @@
     <string name="hint_push_package_name">Push notification sender (application name) </string>
     <string name="hint_push_content_template">Push notification text template (optional)</string>
     <string name="push_package_invalid_name">Incorrect push notification sender app name</string>
+
+    <string name="menu_settings">Settings</string>
+    <string name="settings_header_debug">Debug Settings</string>
+    <string name="settings_debug_push_label">Send push notifications for debug</string>
+    <string name="settings_debug_push_help">When enabled, all incoming push notifications will be sent to the backend for debugging</string>
 
 </resources>


### PR DESCRIPTION
This commit implements a new Settings page in the mobile app with a toggle to send all incoming push notifications to the backend /logs endpoint for debugging purposes.

Changes:
- Add Settings screen accessible from navigation drawer with debug toggle
- Implement debug logging that sends all push notifications to /logs endpoint
- Add dual broadcast pattern: debug broadcast (when enabled) + normal broadcast
- Fix Android 13+ (TIRAMISU) compatibility for getParcelableExtra() calls
- Add explicit broadcast intents with setPackage() to comply with Android restrictions
- Implement notification deduplication to prevent duplicate logs when Android calls onNotificationPosted() multiple times for the same notification
- Add proper toolbar title updates when navigating to Settings

Technical implementation:
- PushListenerService: Added deduplication cache and empty text filtering
- ProcessingService: Added DebugBroadcastReceiver for handling debug broadcasts
- SharedPreferencesProvider: Added debug push notifications preference storage
- JSON format includes: type, timestamp (ISO 8601), packageName, text, postTime
- Fire-and-forget async logging with RxJava (no retry, no storage)
- Per-user preference setting (default: false)