### PR TITLE
Suppress client disconnection exceptions from email notifications (#49)

### DIFF
--- a/backend/src/main/java/by/bk/GlobalExceptionResolver.java
+++ b/backend/src/main/java/by/bk/GlobalExceptionResolver.java
@@ -16,11 +16,14 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ErrorHandler;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.handler.SimpleMappingExceptionResolver;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 /**
@@ -28,42 +31,61 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
  */
 @Component
 public class GlobalExceptionResolver extends SimpleMappingExceptionResolver implements ErrorHandler {
-    private static final Log LOG = LogFactory.getLog(GlobalExceptionResolver.class);
-    private static final String REPLACE_PATTERN = System.getProperty("line.separator");
-    private static final String REPLACEMENT = "<br>&emsp;";
-    private static final String SYSTEM_USER = "SYSTEM";
-    private static final List<Class> EXPECTED_EXCEPTIONS = List.of(BadCredentialsException.class, NoResourceFoundException.class, HttpMediaTypeNotAcceptableException.class);
 
-    @Value("${mail.admin.username}")
-    private String toEmail;
-    @Value("${mail.exception.notify}")
-    private boolean notify;
-    @Autowired
-    private EmailPreparator exceptionNotificationEmailPreparator;
+  private static final Log LOG = LogFactory.getLog(GlobalExceptionResolver.class);
+  private static final String REPLACE_PATTERN = System.getProperty("line.separator");
+  private static final String REPLACEMENT = "<br>&emsp;";
+  private static final String SYSTEM_USER = "SYSTEM";
+  private static final List<Class> EXPECTED_EXCEPTIONS = List.of(
+      BadCredentialsException.class,
+      NoResourceFoundException.class,
+      HttpMediaTypeNotAcceptableException.class,
+      AsyncRequestNotUsableException.class,
+      ClientAbortException.class
+  );
 
-    @PostConstruct
-    public void init() {
-        super.setOrder(Ordered.HIGHEST_PRECEDENCE);
+  @Value("${mail.admin.username}")
+  private String toEmail;
+  @Value("${mail.exception.notify}")
+  private boolean notify;
+  @Autowired
+  private EmailPreparator exceptionNotificationEmailPreparator;
+
+  @PostConstruct
+  public void init() {
+    super.setOrder(Ordered.HIGHEST_PRECEDENCE);
+  }
+
+  @Override
+  protected ModelAndView doResolveException(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+    if (!isExpectedException(ex)) {
+      String stackTrace = RegExUtils.replaceAll(ExceptionUtils.getStackTrace(ex), REPLACE_PATTERN, REPLACEMENT);
+      Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+      if (notify) {
+        exceptionNotificationEmailPreparator.prepareAndSend(toEmail, LocalDateTime.now(), principal, stackTrace);
+      }
     }
+    return super.doResolveException(request, response, handler, ex);
+  }
 
-    @Override
-    protected ModelAndView doResolveException(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
-        if (!EXPECTED_EXCEPTIONS.contains(ex.getClass())) {
-            String stackTrace = RegExUtils.replaceAll(ExceptionUtils.getStackTrace(ex), REPLACE_PATTERN, REPLACEMENT);
-            Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-            if (notify) {
-                exceptionNotificationEmailPreparator.prepareAndSend(toEmail, LocalDateTime.now(), principal, stackTrace);
-            }
-        }
-        return super.doResolveException(request, response, handler, ex);
+  private boolean isExpectedException(Exception ex) {
+    // Check if exception class matches any expected exception
+    for (Class<?> expectedClass : EXPECTED_EXCEPTIONS) {
+      if (expectedClass.isInstance(ex)) {
+        return true;
+      }
     }
+    // Check if root cause is a client disconnection (Broken pipe)
+    var rootCause = ExceptionUtils.getRootCause(ex);
+    return rootCause instanceof IOException && rootCause.getMessage() != null && rootCause.getMessage().contains("Broken pipe");
+  }
 
-    @Override
-    public void handleError(Throwable t) {
-        LOG.error(t.getMessage(), t);
-        String stackTrace = RegExUtils.replaceAll(ExceptionUtils.getStackTrace(t), REPLACE_PATTERN, REPLACEMENT);
-        if (notify) {
-            exceptionNotificationEmailPreparator.prepareAndSend(toEmail, LocalDateTime.now(), SYSTEM_USER, stackTrace);
-        }
+  @Override
+  public void handleError(Throwable t) {
+    LOG.error(t.getMessage(), t);
+    String stackTrace = RegExUtils.replaceAll(ExceptionUtils.getStackTrace(t), REPLACE_PATTERN, REPLACEMENT);
+    if (notify) {
+      exceptionNotificationEmailPreparator.prepareAndSend(toEmail, LocalDateTime.now(), SYSTEM_USER, stackTrace);
     }
+  }
 }


### PR DESCRIPTION
Client disconnection errors (AsyncRequestNotUsableException, ClientAbortException, Broken pipe) are normal occurrences when clients close connections before the server finishes responding. These should not trigger admin email notifications.