### PR TITLE
Fix crash when foreground service quota exhausted on Android 14+

### DIFF
--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -13,7 +13,7 @@ android {
         applicationId "by.bk.bookkeeper.android"
         minSdkVersion 28
         targetSdkVersion 35
-        versionCode 21
+        versionCode 22
         versionName "2.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Wrap startForeground() in try-catch to handle ForegroundServiceStartNotAllowedException. On Android 14+, dataSync foreground services have a ~6 hour daily limit. When exhausted, the service now logs a warning and continues without foreground status instead of crashing. Existing retry mechanisms (SharedPreferences + WorkManager) handle any lost messages.