### PR TITLE
Fix multipart parsing exceptions from spam requests (#62)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>by.bk</groupId>
     <artifactId>bookkeeper-backend</artifactId>
-    <version>3.3.3</version>
+    <version>3.3.4</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/backend/src/main/java/by/bk/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/by/bk/controller/GlobalExceptionHandler.java
@@ -3,9 +3,12 @@ package by.bk.controller;
 import org.apache.catalina.connector.ClientAbortException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
+import org.springframework.web.multipart.MultipartException;
 
 /**
  * Global exception handler for handling client disconnection exceptions.
@@ -36,5 +39,17 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ClientAbortException.class)
     public void handleClientAbort(ClientAbortException ex) {
         LOG.debug("Client aborted connection: " + ex.getMessage());
+    }
+
+    /**
+     * Handles MultipartException thrown when parsing malformed multipart requests.
+     * This commonly occurs from spam/bot traffic sending invalid multipart/form-data
+     * requests. Since this API doesn't use multipart file uploads, these are
+     * typically malicious or malformed requests that should be rejected.
+     */
+    @ExceptionHandler(MultipartException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public void handleMultipartException(MultipartException ex) {
+        LOG.debug("Failed to parse multipart request (likely spam): " + ex.getMessage());
     }
 }

--- a/backend/src/main/java/by/bk/filter/HandleSpamRequestsFilter.java
+++ b/backend/src/main/java/by/bk/filter/HandleSpamRequestsFilter.java
@@ -7,26 +7,43 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
-import org.springframework.util.InvalidMimeTypeException;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+/**
+ * Filter to reject spam and malformed requests early in the request pipeline.
+ * This filter runs at highest precedence to block invalid requests before
+ * they consume server resources.
+ *
+ * @author Sergey Koval
+ */
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class HandleSpamRequestsFilter extends OncePerRequestFilter {
     private static final String ACCEPT = "Accept";
     private static final String INVALID_MIME_TYPE = "Invalid mime type";
+    private static final String MULTIPART_NOT_SUPPORTED = "Multipart requests are not supported";
 
     @Override
     protected void doFilterInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, FilterChain filterChain) throws ServletException, IOException {
-        String header = httpServletRequest.getHeader(ACCEPT);
-        if (StringUtils.isNotBlank(header)) {
+        // Reject multipart requests - this API only accepts JSON
+        // Multipart requests are typically spam/bot traffic attempting to upload files
+        var contentType = httpServletRequest.getContentType();
+        if (contentType != null && contentType.toLowerCase().startsWith(MediaType.MULTIPART_FORM_DATA_VALUE)) {
+            httpServletResponse.sendError(HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE, MULTIPART_NOT_SUPPORTED);
+            return;
+        }
+
+        // Validate Accept header MIME type
+        var acceptHeader = httpServletRequest.getHeader(ACCEPT);
+        if (StringUtils.isNotBlank(acceptHeader)) {
             try {
-                MediaType.parseMediaTypes(header);
-            } catch (InvalidMimeTypeException e) {
+                MediaType.parseMediaTypes(acceptHeader);
+            } catch (InvalidMediaTypeException e) {
                 httpServletResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, INVALID_MIME_TYPE);
                 return;
             }

--- a/backend/src/test/java/by/bk/controller/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/by/bk/controller/GlobalExceptionHandlerTest.java
@@ -3,6 +3,7 @@ package by.bk.controller;
 import org.apache.catalina.connector.ClientAbortException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,10 +12,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
+import org.springframework.web.multipart.MultipartException;
 
 import java.io.IOException;
-
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -51,6 +51,14 @@ class GlobalExceptionHandlerTest {
             .andExpect(status().isOk());
     }
 
+    @Test
+    void shouldHandleMultipartException() throws Exception {
+        // When endpoint throws MultipartException (e.g., from malformed multipart request)
+        // Then it should return 400 Bad Request without logging stack trace
+        mockMvc.perform(get("/test/multipart-error"))
+            .andExpect(status().isBadRequest());
+    }
+
     @Configuration
     static class TestConfig {
         @Bean
@@ -69,6 +77,11 @@ class GlobalExceptionHandlerTest {
         @GetMapping("/test/client-abort")
         public String throwClientAbort() throws IOException {
             throw new ClientAbortException(new IOException("Broken pipe"));
+        }
+
+        @GetMapping("/test/multipart-error")
+        public String throwMultipartException() {
+            throw new MultipartException("Stream ended unexpectedly");
         }
     }
 }

--- a/backend/src/test/java/by/bk/filter/HandleSpamRequestsFilterTest.java
+++ b/backend/src/test/java/by/bk/filter/HandleSpamRequestsFilterTest.java
@@ -1,0 +1,78 @@
+package by.bk.filter;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Test that verifies HandleSpamRequestsFilter properly rejects spam requests.
+ *
+ * @author Sergey Koval
+ */
+@WebMvcTest(excludeAutoConfiguration = SecurityAutoConfiguration.class)
+@ContextConfiguration(classes = {
+    HandleSpamRequestsFilterTest.TestConfig.class,
+    HandleSpamRequestsFilter.class
+})
+class HandleSpamRequestsFilterTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldRejectMultipartRequests() throws Exception {
+        // Multipart requests should be rejected with 415 Unsupported Media Type
+        // since this API only accepts JSON
+        mockMvc.perform(post("/test/endpoint")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .content("--boundary\r\nContent-Disposition: form-data; name=\"file\"\r\n\r\ntest\r\n--boundary--"))
+            .andExpect(status().isUnsupportedMediaType());
+    }
+
+    @Test
+    void shouldRejectInvalidAcceptHeader() throws Exception {
+        // Requests with invalid Accept headers should be rejected
+        mockMvc.perform(post("/test/endpoint")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Accept", "invalid/mime/type/with/extra/slashes")
+                .content("{}"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldAllowValidJsonRequests() throws Exception {
+        // Valid JSON requests should pass through
+        mockMvc.perform(post("/test/endpoint")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andExpect(status().isOk());
+    }
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        public TestController testController() {
+            return new TestController();
+        }
+    }
+
+    @RestController
+    static class TestController {
+        @PostMapping("/test/endpoint")
+        public String testEndpoint() {
+            return "ok";
+        }
+    }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bk",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "license": "MIT",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
- Reject multipart/form-data requests early in HandleSpamRequestsFilter since this API only accepts JSON (returns 415 Unsupported Media Type)
- Add MultipartException handler to GlobalExceptionHandler to gracefully handle any malformed multipart requests that slip through (returns 400)
- Fix bug: catch InvalidMediaTypeException instead of InvalidMimeTypeException when validating Accept header
- Add tests for both filter and exception handler
- Bump version to 3.3.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)