### PR TITLE
Fix ForegroundServiceDidNotStartInTimeException crash (#65)

### DIFF
--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -13,7 +13,7 @@ android {
         applicationId "by.bk.bookkeeper.android"
         minSdkVersion 28
         targetSdkVersion 35
-        versionCode 23
+        versionCode 24
         versionName "2.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Move startForeground() call to the beginning of onStartCommand() before any permission checks or early returns. Android requires startForeground() to be called within 5 seconds of startForegroundService(), regardless of what the service decides to do afterward.

Previously, when SMS permission was revoked or logout action was received, the service would call stopForeground() and stopSelf() without ever calling startForeground(), violating Android's foreground service contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)