### PR TITLE
Fix multipart parsing exceptions during error page forwarding

### DIFF
--- a/backend/src/main/java/by/bk/filter/HandleSpamRequestsFilter.java
+++ b/backend/src/main/java/by/bk/filter/HandleSpamRequestsFilter.java
@@ -18,12 +18,27 @@ import java.io.IOException;
  * Filter to reject spam and malformed requests early in the request pipeline.
  * This filter runs at highest precedence to block invalid requests before
  * they consume server resources.
+ * <p>
+ * This filter also runs during ERROR dispatches to prevent multipart parsing
+ * exceptions when Tomcat forwards to error pages.
  *
  * @author Sergey Koval
  */
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class HandleSpamRequestsFilter extends OncePerRequestFilter {
+
+    /**
+     * Also filter ERROR dispatches to block multipart requests during error page forwarding.
+     * When an error occurs, Tomcat forwards to /error with the original request, which still
+     * has the multipart content-type. Without filtering ERROR dispatches, Spring's
+     * DispatcherServlet tries to parse the malformed multipart body and throws.
+     */
+    @Override
+    protected boolean shouldNotFilterErrorDispatch() {
+        return false;
+    }
+
     private static final String ACCEPT = "Accept";
     private static final String INVALID_MIME_TYPE = "Invalid mime type";
     private static final String MULTIPART_NOT_SUPPORTED = "Multipart requests are not supported";

--- a/backend/src/test/java/by/bk/filter/HandleSpamRequestsFilterTest.java
+++ b/backend/src/test/java/by/bk/filter/HandleSpamRequestsFilterTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -76,6 +77,15 @@ class HandleSpamRequestsFilterTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .content("{}"))
             .andExpect(status().isOk());
+    }
+
+    @Test
+    void shouldFilterErrorDispatches() {
+        // The filter must also run during ERROR dispatches to prevent multipart parsing
+        // exceptions when Tomcat forwards to error pages with the original multipart request
+        HandleSpamRequestsFilter filter = new HandleSpamRequestsFilter();
+        // shouldNotFilterErrorDispatch() must return false (i.e., DO filter error dispatches)
+        assertThat(filter.shouldNotFilterErrorDispatch()).isFalse();
     }
 
     @Configuration


### PR DESCRIPTION
The previous fix blocked multipart requests on the original REQUEST dispatch, but OncePerRequestFilter by default does not filter ERROR dispatches. When Tomcat forwards to /error after some other error, Spring's DispatcherServlet tries to parse the multipart body again, causing "Stream ended unexpectedly".

- Override shouldNotFilterErrorDispatch() to return false so filter also runs during ERROR dispatches
- Add test to verify the filter handles error dispatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)