### PR TITLE
Fix ForegroundServiceDidNotStartInTimeException with bulletproof fall…

### DIFF
--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -13,7 +13,7 @@ android {
         applicationId "by.bk.bookkeeper.android"
         minSdkVersion 28
         targetSdkVersion 35
-        versionCode 24
+        versionCode 25
         versionName "2.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
…back

The previous fix could still fail if buildFallbackNotification() threw an exception other than ForegroundServiceStartNotAllowedException, leaving startForeground() never called.

New startForegroundSafely() method uses 3-tier fallback strategy:
1. Full-featured notification (buildNotificationSafely)
2. Minimal app notification (buildFallbackNotification)
3. Last resort: inline notification with system icon only

This guarantees startForeground() is called unless foreground quota is exhausted (Android 14+ dataSync limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)