### PR TITLE
Fix income budget progress bar not showing for categories with undefined currency values (#70)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>by.bk</groupId>
     <artifactId>bookkeeper-backend</artifactId>
-    <version>3.3.4</version>
+    <version>3.3.5</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bk",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/frontend/src/app/common/service/budget.service.ts
+++ b/frontend/src/app/common/service/budget.service.ts
@@ -158,17 +158,19 @@ export class BudgetService {
       const baseCurrency: string = balance.hasOwnProperty(defaultCurrency.name) ? defaultCurrency.name : currencies[0];
       currencies.forEach(currency => {
         const currencyBalance: BudgetBalance = balance[currency];
+        const balanceValue: number = currencyBalance.value || 0;
+        const balanceCompleteValue: number = currencyBalance.completeValue || 0;
         if (currency === baseCurrency) {
-          value = value + currencyBalance.value;
-          completeValue = completeValue + currencyBalance.completeValue;
+          value = value + balanceValue;
+          completeValue = completeValue + balanceCompleteValue;
         } else {
-          value = value + this._currencyService.convertToCurrency(currencyBalance.value, currency, baseCurrency);
-          completeValue = completeValue + this._currencyService.convertToCurrency(currencyBalance.completeValue, currency, baseCurrency);
+          value = value + this._currencyService.convertToCurrency(balanceValue, currency, baseCurrency);
+          completeValue = completeValue + this._currencyService.convertToCurrency(balanceCompleteValue, currency, baseCurrency);
         }
       });
     } else {
-      value = value + balance[currencies[0]].value;
-      completeValue = balance[currencies[0]].completeValue;
+      value = value + (balance[currencies[0]].value || 0);
+      completeValue = balance[currencies[0]].completeValue || 0;
     }
 
     if (completeValue === 0) {


### PR DESCRIPTION
Handle undefined/null values in calculatePercentDone to prevent NaN results when a currency balance has missing value property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)