### PR TITLE
Fix ForegroundServiceDidNotStartInTimeException by calling startForeg…

### DIFF
--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -13,7 +13,7 @@ android {
         applicationId "by.bk.bookkeeper.android"
         minSdkVersion 28
         targetSdkVersion 35
-        versionCode 25
+        versionCode 26
         versionName "2.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/mobile/app/src/main/java/by/bk/bookkeeper/processor/ProcessingService.kt
+++ b/mobile/app/src/main/java/by/bk/bookkeeper/processor/ProcessingService.kt
@@ -65,6 +65,13 @@ class ProcessingService : Service() {
         super.onCreate()
         Timber.d("Service on create invoked")
         createNotificationChannel()
+        // CRITICAL: Call startForeground() immediately after channel creation.
+        // The 5-second window starts when startForegroundService() is called by the caller,
+        // NOT when onStartCommand() runs. If onCreate() takes too long (WorkManager init,
+        // process cold-start, memory pressure), onStartCommand() may never be reached in time.
+        // This ensures the foreground contract is satisfied ASAP. onStartCommand() will
+        // call startForegroundSafely() again to update the notification with correct content.
+        startForegroundSafely()
         PeriodicMessagesScheduler.schedule(context = this)
         observePendingMessages()
         observeUnprocessedSms()


### PR DESCRIPTION
…round() in onCreate()

The previous fixes called startForeground() in onStartCommand(), but Android's 5-second window starts when startForegroundService() is called by the caller, not when onStartCommand() runs. If onCreate() takes too long (WorkManager init, process cold-start, memory pressure), onStartCommand() may not be reached in time.

Now startForegroundSafely() is called in onCreate() immediately after creating the notification channel, ensuring the foreground contract is satisfied ASAP. The subsequent call in onStartCommand() updates the notification with correct content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)