### PR TITLE
Fix category-value vertical positioning for multi-currency stacking

### DIFF
--- a/frontend/src/app/budget/budget-details/budget-details.component.css
+++ b/frontend/src/app/budget/budget-details/budget-details.component.css
@@ -147,8 +147,6 @@
 .category-value {
   position: absolute;
   right: 5px;
-  top: 50%;
-  transform: translateY(-50%);
 }
 
 .vertical-middle {

--- a/frontend/src/app/budget/close-month-dialog/close-month-dialog.component.css
+++ b/frontend/src/app/budget/close-month-dialog/close-month-dialog.component.css
@@ -167,8 +167,6 @@
 .category-value {
   position: absolute;
   right: 5px;
-  top: 50%;
-  transform: translateY(-50%);
 }
 
 .action-plan {


### PR DESCRIPTION
Remove top/transform centering from .category-value since it uses inline [style.top.px] for stacking multiple currency values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)