### PR TITLE
Fix category-value vertical alignment in close-month-dialog

### DIFF
--- a/frontend/src/app/budget/close-month-dialog/close-month-dialog.component.css
+++ b/frontend/src/app/budget/close-month-dialog/close-month-dialog.component.css
@@ -167,6 +167,7 @@
 .category-value {
   position: absolute;
   right: 5px;
+  line-height: 20px;
 }
 
 .action-plan {


### PR DESCRIPTION
Add line-height: 20px to center text within each 20px currency slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)