### PR TITLE
Fix ForegroundServiceDidNotStartInTimeException with lazy dependency …

### DIFF
--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -13,7 +13,7 @@ android {
         applicationId "by.bk.bookkeeper.android"
         minSdkVersion 28
         targetSdkVersion 35
-        versionCode 26
+        versionCode 27
         versionName "2.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/mobile/app/src/main/java/by/bk/bookkeeper/processor/ProcessingService.kt
+++ b/mobile/app/src/main/java/by/bk/bookkeeper/processor/ProcessingService.kt
@@ -40,11 +40,15 @@ class ProcessingService : Service() {
 
     private lateinit var pushReceiver: PushBroadcastReceiver
     private lateinit var debugReceiver: DebugBroadcastReceiver
-    private val repository = Injection.provideMessagesRepository()
-    private val smsProcessor = Injection.provideSmsProcessor()
-    private val pushProcessor = Injection.providePushProcessor()
+    // CRITICAL: Use lazy initialization to avoid blocking onCreate().
+    // The 5-second foreground service deadline starts when startForegroundService() is called.
+    // If property initializers (especially network stack creation) take too long,
+    // onCreate() won't be reached in time to call startForeground().
+    private val repository by lazy { Injection.provideMessagesRepository() }
+    private val smsProcessor by lazy { Injection.provideSmsProcessor() }
+    private val pushProcessor by lazy { Injection.providePushProcessor() }
     private val disposables = CompositeDisposable()
-    private val gson = com.google.gson.Gson()
+    private val gson by lazy { com.google.gson.Gson() }
 
     // State for notification content (updated from any thread, read only from main thread)
     @Volatile private var pendingSmsCount: Int = 0


### PR DESCRIPTION
…initialization

Root cause: Property initializers (repository, smsProcessor, pushProcessor, gson) ran before onCreate(), blocking it. The network stack creation (OkHttpClient, Retrofit, Gson) on cold start could exceed Android's 5-second deadline.

Previous fixes called startForeground() in onCreate(), but onCreate() itself was delayed by eager property initialization.

Solution: Use `by lazy` for all expensive dependencies. Now:
- Class construction is instant
- onCreate() runs immediately
- startForeground() is called in time
- Dependencies initialize only when first SMS/push arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)