### PR TITLE
Add tags management page in settings (#80)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>by.bk</groupId>
     <artifactId>bookkeeper-backend</artifactId>
-    <version>3.3.6</version>
+    <version>3.4.0</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/backend/src/main/java/by/bk/controller/ProfileController.java
+++ b/backend/src/main/java/by/bk/controller/ProfileController.java
@@ -200,4 +200,19 @@ public class ProfileController extends BaseAPIController {
     public SimpleResponse removeDevice(Principal principal, @PathVariable("deviceId") String deviceId) {
         return userAPI.removeDevice(principal.getName(), deviceId);
     }
+
+    @PostMapping("/tags")
+    public SimpleResponse addTag(@RequestBody TagRequest request, Principal principal) {
+        return userAPI.addTag(principal.getName(), request.getTitle(), request.getColor(), request.getTextColor());
+    }
+
+    @PutMapping("/tags")
+    public SimpleResponse editTag(@RequestBody TagRequest request, Principal principal) {
+        return userAPI.editTag(principal.getName(), request.getOldTitle(), request.getTitle(), request.getColor(), request.getTextColor(), request.getActive());
+    }
+
+    @DeleteMapping("/tags/{title}")
+    public SimpleResponse deleteTag(Principal principal, @PathVariable("title") String title) {
+        return userAPI.deleteTag(principal.getName(), title);
+    }
 }

--- a/backend/src/main/java/by/bk/controller/model/request/TagRequest.java
+++ b/backend/src/main/java/by/bk/controller/model/request/TagRequest.java
@@ -1,0 +1,12 @@
+package by.bk.controller.model.request;
+
+import lombok.Getter;
+
+@Getter
+public class TagRequest {
+    private String title;
+    private String oldTitle;
+    private String color;
+    private String textColor;
+    private Boolean active;
+}

--- a/backend/src/main/java/by/bk/entity/user/UserAPI.java
+++ b/backend/src/main/java/by/bk/entity/user/UserAPI.java
@@ -66,4 +66,8 @@ public interface UserAPI extends AuthenticationAPI {
     SimpleResponse changeDeviceName(String login, ChangeDeviceNameRequest deviceDetails);
     SimpleResponse logoutDevice(String login, String deviceId);
     SimpleResponse removeDevice(String login, String deviceId);
+
+    SimpleResponse addTag(String login, String title, String color, String textColor);
+    SimpleResponse editTag(String login, String oldTitle, String newTitle, String color, String textColor, Boolean active);
+    SimpleResponse deleteTag(String login, String title);
 }

--- a/backend/src/main/java/by/bk/entity/user/model/Tag.java
+++ b/backend/src/main/java/by/bk/entity/user/model/Tag.java
@@ -1,0 +1,19 @@
+package by.bk.entity.user.model;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Tag {
+    private String title;
+    private String color;
+    @Builder.Default
+    private String textColor = "#FFFFFF";
+    @Builder.Default
+    private boolean active = true;
+}

--- a/backend/src/main/java/by/bk/entity/user/model/User.java
+++ b/backend/src/main/java/by/bk/entity/user/model/User.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -30,6 +31,7 @@ public class User {
     private List<Category> categories;
     private List<Account> accounts;
     private Map<String, Device> devices = new HashMap<>();
+    private List<Tag> tags = new ArrayList<>();
 
     public User() {
     }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bk",
-  "version": "3.3.6",
+  "version": "3.4.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/frontend/src/app/bk.module.ts
+++ b/frontend/src/app/bk.module.ts
@@ -95,6 +95,8 @@ import { DeviceMailDialogComponent } from './settings/devices/device-mail-dialog
 import { DeviceNameDialogComponent } from './settings/devices/device-name-dialog/device-name-dialog.component';
 import { DeviceMessageDialogComponent } from './settings/devices/device-message-dialog/device-message-dialog.component';
 import { DeviceMessageAssignDialogComponent } from './history/device-message-assign-dialog/device-message-assign-dialog.component';
+import { TagsComponent } from './settings/tags/tags.component';
+import { TagDialogComponent } from './settings/tags/tag-dialog/tag-dialog.component';
 import { ToggleComponent } from './common/components/toggle/toggle.component';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -176,6 +178,8 @@ import { PeriodFilterComponent } from './reports/period-filter/period-filter.com
     DeviceNameDialogComponent,
     DeviceMessageDialogComponent,
     DeviceMessageAssignDialogComponent,
+    TagsComponent,
+    TagDialogComponent,
     ToggleComponent,
     InputComponent,
     SpinnerComponent

--- a/frontend/src/app/common/model/profile.ts
+++ b/frontend/src/app/common/model/profile.ts
@@ -2,6 +2,7 @@ import { CurrencyDetail } from './currency-detail';
 import { Category } from './category';
 import { FinAccount } from './fin-account';
 import { Device } from './device';
+import { Tag } from './tag';
 
 export interface Profile {
   id: number;
@@ -11,4 +12,5 @@ export interface Profile {
   categories: Category[];
   accounts: FinAccount[];
   devices: {[deviceId: string]: Device};
+  tags: Tag[];
 }

--- a/frontend/src/app/common/model/tag.ts
+++ b/frontend/src/app/common/model/tag.ts
@@ -1,0 +1,6 @@
+export interface Tag {
+  title: string;
+  color: string;
+  textColor: string;
+  active: boolean;
+}

--- a/frontend/src/app/common/service/profile.service.ts
+++ b/frontend/src/app/common/service/profile.service.ts
@@ -140,6 +140,12 @@ export class ProfileService  {
     return this.getUserProfile().pipe(tap(profile => this.authenticatedProfile.devices = profile.devices));
   }
 
+  public reloadTagsInProfile(): Observable<Profile> {
+    return this.getUserProfile().pipe(tap(profile => {
+      this.authenticatedProfile.tags = profile.tags || [];
+    }));
+  }
+
   public clearProfile(): void {
     this._authenticatedProfile = null;
     this._userCurrencies.clear();
@@ -423,6 +429,18 @@ export class ProfileService  {
 
   public removeDevice(deviceId: string): Observable<SimpleResponse> {
     return this._http.delete<SimpleResponse>(`/api/profile/devices/${deviceId}`);
+  }
+
+  public addTag(title: string, color: string, textColor: string): Observable<SimpleResponse> {
+    return this._http.post<SimpleResponse>('/api/profile/tags', {title, color, textColor});
+  }
+
+  public editTag(oldTitle: string, title: string, color: string, textColor: string, active: boolean): Observable<SimpleResponse> {
+    return this._http.put<SimpleResponse>('/api/profile/tags', {oldTitle, title, color, textColor, active});
+  }
+
+  public deleteTag(title: string): Observable<SimpleResponse> {
+    return this._http.delete<SimpleResponse>(`/api/profile/tags/${encodeURIComponent(title)}`);
   }
 
   public static chooseSelectedItem(items: SelectItem[], firstLevel: string, secondLevel: string): SelectItem[] {

--- a/frontend/src/app/routes.ts
+++ b/frontend/src/app/routes.ts
@@ -15,6 +15,7 @@ import { ReportActionsComponent } from './reports/report-actions/report-actions.
 import { ReportSummaryComponent } from './reports/report-summary/report-summary.component';
 import { ReportDynamicComponent } from './reports/report-dynamic/report-dynamic.component';
 import { DevicesComponent } from './settings/devices/devices.component';
+import { TagsComponent } from './settings/tags/tags.component';
 
 export const BOOKKEEPING_ROUTES: Route[] = [
   {
@@ -104,7 +105,12 @@ export const BOOKKEEPING_ROUTES: Route[] = [
       {
         path: 'devices',
         component: DevicesComponent,
-        data: {title: 'Бухгалтерия - настройки - Девайсы'}
+        data: {title: 'Бухгалтерия - настройки - девайсы'}
+      },
+      {
+        path: 'tags',
+        component: TagsComponent,
+        data: {title: 'Бухгалтерия - настройки - тэги'}
       }
     ]
   }

--- a/frontend/src/app/settings/settings.component.html
+++ b/frontend/src/app/settings/settings.component.html
@@ -4,6 +4,7 @@
   <li role="presentation" routerLinkActive="active"><a [routerLink]="['/settings/accounts']">Счета</a></li>
   <li role="presentation" routerLinkActive="active"><a [routerLink]="['/settings/categories']">Категории</a></li>
   <li role="presentation" routerLinkActive="active"><a [routerLink]="['/settings/devices']">Девайсы</a></li>
+  <li role="presentation" routerLinkActive="active"><a [routerLink]="['/settings/tags']">Тэги</a></li>
 </ul>
 
 <div class="panel panel-default">

--- a/frontend/src/app/settings/tags/tag-dialog/tag-dialog.component.css
+++ b/frontend/src/app/settings/tags/tag-dialog/tag-dialog.component.css
@@ -1,0 +1,129 @@
+#tag-dialog {
+  min-width: 400px;
+}
+
+.left-column {
+  line-height: 34px;
+  font-size: 16px;
+}
+
+.title {
+  padding-bottom: 10px;
+}
+
+.right-column {
+  padding-left: 0;
+  padding-right: 10px;
+}
+
+.color-picker {
+  padding: 10px 0;
+}
+
+.left-column + .color-picker,
+.left-column + .text-color-picker {
+  padding-top: 0;
+}
+
+.row:has(.color-picker) .left-column,
+.row:has(.text-color-picker) .left-column {
+  padding-top: 5px;
+  line-height: normal;
+}
+
+.preset-colors {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 15px;
+}
+
+.color-swatch {
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: border-color 0.2s;
+}
+
+.color-swatch:hover {
+  border-color: #666;
+}
+
+.color-swatch.selected {
+  border-color: #333;
+  box-shadow: 0 0 4px rgba(0,0,0,0.3);
+}
+
+.text-color-picker {
+  padding: 10px 0;
+}
+
+.preset-text-colors {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 15px;
+}
+
+.text-color-swatch {
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 2px solid #ccc;
+  transition: border-color 0.2s;
+}
+
+.text-color-swatch:hover {
+  border-color: #666;
+}
+
+.text-color-swatch.selected {
+  border-color: #333;
+  box-shadow: 0 0 4px rgba(0,0,0,0.3);
+}
+
+.preview-container {
+  padding: 10px 0;
+}
+
+.tag-preview {
+  font-size: 14px;
+  font-weight: normal;
+  padding: 4px 8px;
+}
+
+.custom-color {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.custom-color label {
+  margin: 0;
+  white-space: nowrap;
+}
+
+.custom-color input {
+  width: 100px;
+}
+
+.color-preview {
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+}
+
+.dialog-actions {
+  width: 100%;
+}
+
+.action-item {
+  float: right;
+}
+
+.error {
+  margin-bottom: 15px;
+}

--- a/frontend/src/app/settings/tags/tag-dialog/tag-dialog.component.html
+++ b/frontend/src/app/settings/tags/tag-dialog/tag-dialog.component.html
@@ -1,0 +1,80 @@
+<h2 mat-dialog-title align="center" bkDraggable dragTarget=".mat-dialog-container">
+  @if (data.editMode) {
+    <span>Редактирование тэга</span>
+  } @else {
+    <span>Новый тэг</span>
+  }
+</h2>
+<mat-dialog-content id="tag-dialog">
+  @if (errorMessage) {
+    <div class="alert alert-dismissable fade in alert-danger error">
+      <strong>{{errorMessage}}</strong>
+    </div>
+  }
+  <div class="table">
+    <div class="row title">
+      <div class="col-sm-3 left-column">Название:</div>
+      <div class="col-sm-9 right-column">
+        <input type="text" [(ngModel)]="title" class="form-control" placeholder="Введите название">
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-3 left-column">Фон:</div>
+      <div class="col-sm-9 color-picker">
+        <div class="preset-colors">
+          @for (presetColor of presetColors; track presetColor) {
+            <span
+              class="color-swatch"
+              [style.background-color]="presetColor"
+              [class.selected]="presetColor === color"
+              (click)="selectColor(presetColor)">
+            </span>
+          }
+        </div>
+        <div class="custom-color">
+          <label>Свой цвет:</label>
+          <input type="text" [(ngModel)]="color" class="form-control" placeholder="#RRGGBB">
+          <span class="color-preview" [style.background-color]="color"></span>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-3 left-column">Текст:</div>
+      <div class="col-sm-9 text-color-picker">
+        <div class="preset-text-colors">
+          @for (txtColor of textColors; track txtColor) {
+            <span
+              class="text-color-swatch"
+              [style.background-color]="txtColor"
+              [class.selected]="txtColor === textColor"
+              (click)="selectTextColor(txtColor)">
+            </span>
+          }
+        </div>
+        <div class="custom-color">
+          <label>Свой цвет:</label>
+          <input type="text" [(ngModel)]="textColor" class="form-control" placeholder="#RRGGBB">
+          <span class="color-preview" [style.background-color]="textColor"></span>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-3 left-column">Результат:</div>
+      <div class="col-sm-9 preview-container">
+        <span class="label tag-preview" [style.background-color]="color" [style.color]="textColor">{{title || 'Название тэга'}}</span>
+      </div>
+    </div>
+  </div>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <span class="dialog-actions">
+    <button class="btn btn-default action-item" (click)="close()">Закрыть</button>
+    <span class="action-item">&nbsp;</span>
+    <button class="btn btn-default action-item" [disabled]="loading" (click)="save()">
+      @if (!loading) {
+        <span>Сохранить</span>
+      }
+      <bk-spinner [display]="loading" [size]="20"></bk-spinner>
+    </button>
+  </span>
+</mat-dialog-actions>

--- a/frontend/src/app/settings/tags/tag-dialog/tag-dialog.component.ts
+++ b/frontend/src/app/settings/tags/tag-dialog/tag-dialog.component.ts
@@ -1,0 +1,99 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+import { ProfileService } from '../../../common/service/profile.service';
+import { Tag } from '../../../common/model/tag';
+
+@Component({
+    selector: 'bk-tag-dialog',
+    templateUrl: './tag-dialog.component.html',
+    styleUrls: ['./tag-dialog.component.css'],
+    standalone: false
+})
+export class TagDialogComponent implements OnInit {
+  public title: string = '';
+  public color: string = '#4CAF50';
+  public textColor: string = '#FFFFFF';
+  public errorMessage: string;
+  public loading: boolean = false;
+
+  private originalTitle: string;
+
+  public presetColors: string[] = [
+    '#F44336', '#E91E63', '#9C27B0', '#673AB7',
+    '#3F51B5', '#2196F3', '#03A9F4', '#00BCD4',
+    '#009688', '#4CAF50', '#8BC34A', '#CDDC39',
+    '#FFEB3B', '#FFC107', '#FF9800', '#FF5722'
+  ];
+
+  public textColors: string[] = ['#FFFFFF', '#000000'];
+
+  public constructor(
+    @Inject(MAT_DIALOG_DATA) public data: {editMode: boolean, tag: Tag},
+    private _dialogRef: MatDialogRef<TagDialogComponent>,
+    private _profileService: ProfileService
+  ) { }
+
+  public ngOnInit(): void {
+    if (this.data.editMode && this.data.tag) {
+      this.title = this.data.tag.title;
+      this.color = this.data.tag.color;
+      this.textColor = this.data.tag.textColor || '#FFFFFF';
+      this.originalTitle = this.data.tag.title;
+    }
+  }
+
+  public selectColor(color: string): void {
+    this.color = color;
+  }
+
+  public selectTextColor(textColor: string): void {
+    this.textColor = textColor;
+  }
+
+  public save(): void {
+    this.errorMessage = null;
+
+    if (!this.title || this.title.trim() === '') {
+      this.errorMessage = 'Название обязательно для заполнения';
+      return;
+    }
+
+    if (!this.color || !/^#[0-9A-Fa-f]{6}$/.test(this.color)) {
+      this.errorMessage = 'Некорректный формат цвета';
+      return;
+    }
+
+    this.loading = true;
+
+    if (this.data.editMode) {
+      this._profileService.editTag(this.originalTitle, this.title.trim(), this.color, this.textColor, this.data.tag.active)
+        .subscribe(result => {
+          this.loading = false;
+          if (result.status === 'FAIL') {
+            this.errorMessage = result.message === 'ALREADY_EXIST'
+              ? 'Тэг с таким названием уже существует'
+              : 'Ошибка при изменении тэга';
+            return;
+          }
+          this._dialogRef.close(true);
+        });
+    } else {
+      this._profileService.addTag(this.title.trim(), this.color, this.textColor)
+        .subscribe(result => {
+          this.loading = false;
+          if (result.status === 'FAIL') {
+            this.errorMessage = result.message === 'ALREADY_EXIST'
+              ? 'Тэг с таким названием уже существует'
+              : 'Ошибка при добавлении тэга';
+            return;
+          }
+          this._dialogRef.close(true);
+        });
+    }
+  }
+
+  public close(): void {
+    this._dialogRef.close(false);
+  }
+}

--- a/frontend/src/app/settings/tags/tags.component.css
+++ b/frontend/src/app/settings/tags/tags.component.css
@@ -1,0 +1,60 @@
+.table {
+  margin-bottom: 0;
+}
+
+.page-title {
+  padding-bottom: 5px;
+  font-size: 16px;
+}
+
+.page-title-text {
+  line-height: 34px;
+}
+
+.tag-separator {
+  border-width: initial;
+}
+
+hr {
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.glyphicon {
+  cursor: pointer;
+  color: #999;
+}
+
+.glyphicon:hover {
+  color: #5e5e5e;
+}
+
+:host ::ng-deep bk-popover .action {
+  padding-right: 5px;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 40px;
+  color: #666;
+}
+
+.tag-label {
+  font-size: 12px;
+  font-weight: normal;
+  padding: 2px 4px;
+}
+
+.inactive-badge {
+  color: #999;
+  font-size: 12px;
+  margin-left: 8px;
+}
+
+.row.inactive {
+  opacity: 0.6;
+}
+
+mat-slide-toggle {
+  margin-left: 10px;
+}

--- a/frontend/src/app/settings/tags/tags.component.html
+++ b/frontend/src/app/settings/tags/tags.component.html
@@ -1,0 +1,44 @@
+<div class="text-center page-title">
+  <button type="button" class="btn btn-default pull-left" (click)="openAddDialog()">Добавить тэг</button>
+  <span class="page-title-text">Тэги</span>
+</div>
+
+@if (tags.length === 0) {
+  <div class="empty-state">
+    <p>Нет созданных тэгов</p>
+  </div>
+}
+
+@if (tags.length > 0) {
+  <div class="table">
+    @for (tag of tags; track tag.title; let last = $last; let first = $first) {
+      <div>
+        @if (first) {
+          <hr class="tag-separator" />
+        }
+        <div class="row" [class.inactive]="!tag.active">
+          <div class="col-sm-8">
+            <span class="label tag-label" [style.background-color]="tag.active ? tag.color : '#999'" [style.color]="tag.active ? tag.textColor : '#fff'">{{tag.title}}</span>
+            @if (!tag.active) {
+              <span class="inactive-badge">(неактивен)</span>
+            }
+          </div>
+          <div class="col-sm-4 text-right">
+            <bk-popover glyphiconClass="stats" text="Отчет" placement="left" (click)="openReport(tag)"></bk-popover>
+            <bk-popover glyphiconClass="pencil" text="Редактировать" placement="left" (click)="openEditDialog(tag)"></bk-popover>
+            <bk-popover glyphiconClass="remove" text="Удалить" placement="left" (click)="confirmDelete(tag)"></bk-popover>
+            <mat-slide-toggle
+              color="primary"
+              [checked]="tag.active"
+              (change)="toggleActive(tag)"
+              matTooltip="{{tag.active ? 'Деактивировать' : 'Активировать'}}">
+            </mat-slide-toggle>
+          </div>
+        </div>
+        @if (!last) {
+          <hr class="tag-separator"/>
+        }
+      </div>
+    }
+  </div>
+}

--- a/frontend/src/app/settings/tags/tags.component.ts
+++ b/frontend/src/app/settings/tags/tags.component.ts
@@ -1,0 +1,115 @@
+import { Component, OnInit } from '@angular/core';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+
+import { filter } from 'rxjs/operators';
+
+import { ProfileService } from '../../common/service/profile.service';
+import { AlertService } from '../../common/service/alert.service';
+import { AlertType } from '../../common/model/alert/AlertType';
+import { LoadingService } from '../../common/service/loading.service';
+import { LoadingDialogComponent } from '../../common/components/loading-dialog/loading-dialog.component';
+import { ConfirmDialogService } from '../../common/components/confirm-dialog/confirm-dialog.service';
+import { Tag } from '../../common/model/tag';
+import { TagDialogComponent } from './tag-dialog/tag-dialog.component';
+
+@Component({
+    selector: 'bk-tags',
+    templateUrl: './tags.component.html',
+    styleUrls: ['./tags.component.css'],
+    standalone: false
+})
+export class TagsComponent implements OnInit {
+  public tags: Tag[] = [];
+
+  public constructor(
+    private _profileService: ProfileService,
+    private _dialog: MatDialog,
+    private _loadingService: LoadingService,
+    private _alertService: AlertService,
+    private _confirmDialogService: ConfirmDialogService
+  ) { }
+
+  public ngOnInit(): void {
+    this.loadTags();
+  }
+
+  private loadTags(): void {
+    const profileTags = this._profileService.authenticatedProfile.tags || [];
+    this.tags = [...profileTags].sort((a, b) => a.title.localeCompare(b.title));
+  }
+
+  public openAddDialog(): void {
+    this._dialog.open(TagDialogComponent, {
+      width: '500px',
+      position: {top: 'top'},
+      data: {editMode: false, tag: null}
+    })
+      .afterClosed()
+      .pipe(filter((result: boolean) => result === true))
+      .subscribe(() => {
+        const loadingDialog: MatDialogRef<LoadingDialogComponent> = this._loadingService.openLoadingDialog('Загрузка...');
+        this._profileService.reloadTagsInProfile().subscribe(() => {
+          this.loadTags();
+          loadingDialog.close();
+          this._alertService.addAlert(AlertType.SUCCESS, 'Тэг добавлен');
+        });
+      });
+  }
+
+  public openEditDialog(tag: Tag): void {
+    this._dialog.open(TagDialogComponent, {
+      width: '500px',
+      position: {top: 'top'},
+      data: {editMode: true, tag: {...tag}}
+    })
+      .afterClosed()
+      .pipe(filter((result: boolean) => result === true))
+      .subscribe(() => {
+        const loadingDialog: MatDialogRef<LoadingDialogComponent> = this._loadingService.openLoadingDialog('Загрузка...');
+        this._profileService.reloadTagsInProfile().subscribe(() => {
+          this.loadTags();
+          loadingDialog.close();
+          this._alertService.addAlert(AlertType.SUCCESS, 'Тэг изменен');
+        });
+      });
+  }
+
+  public confirmDelete(tag: Tag): void {
+    this._confirmDialogService.openConfirmDialog('Подтверждение действия', `Удалить тэг "${tag.title}"?`)
+      .afterClosed()
+      .pipe(filter((result: boolean) => result === true))
+      .subscribe(() => {
+        const loadingDialog: MatDialogRef<LoadingDialogComponent> = this._loadingService.openLoadingDialog('Удаление тэга...');
+        this._profileService.deleteTag(tag.title).subscribe(response => {
+          this._profileService.reloadTagsInProfile().subscribe(() => {
+            this.loadTags();
+            loadingDialog.close();
+            if (response.status === 'SUCCESS') {
+              this._alertService.addAlert(AlertType.SUCCESS, 'Тэг удален');
+            } else {
+              this._alertService.addAlert(AlertType.WARNING, 'Ошибка при удалении тэга');
+            }
+          });
+        });
+      });
+  }
+
+  public toggleActive(tag: Tag): void {
+    const loadingDialog: MatDialogRef<LoadingDialogComponent> = this._loadingService.openLoadingDialog('Сохранение...');
+    this._profileService.editTag(tag.title, tag.title, tag.color, tag.textColor, !tag.active).subscribe(response => {
+      this._profileService.reloadTagsInProfile().subscribe(() => {
+        this.loadTags();
+        loadingDialog.close();
+        if (response.status === 'SUCCESS') {
+          this._alertService.addAlert(AlertType.SUCCESS, tag.active ? 'Тэг деактивирован' : 'Тэг активирован');
+        } else {
+          this._alertService.addAlert(AlertType.WARNING, 'Ошибка при изменении статуса тэга');
+        }
+      });
+    });
+  }
+
+  public openReport(tag: Tag): void {
+    this._alertService.addAlert(AlertType.INFO, 'Функция будет доступна позже');
+  }
+}


### PR DESCRIPTION
- Add Tag model with title, color, textColor, and active status
- Add REST API endpoints: POST/PUT/DELETE /api/profile/tags
- Add tags settings page at /settings/tags with CRUD operations
- Add tag dialog with color pickers for background and text colors
- Add live preview in tag dialog
- Support activating/deactivating tags
- Tags displayed as colored labels with customizable text color
- Version bump to 3.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)