### PR TITLE
Add tags support for history items (#29)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>by.bk</groupId>
     <artifactId>bookkeeper-backend</artifactId>
-    <version>3.4.0</version>
+    <version>3.4.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/backend/src/main/java/by/bk/entity/history/HistoryItem.java
+++ b/backend/src/main/java/by/bk/entity/history/HistoryItem.java
@@ -42,6 +42,7 @@ public class HistoryItem {
     private String goal;
     private List<DeviceMessage> deviceMessages;
     private List<DeviceMessage> duplicateMessages;
+    private List<String> tags;
 
     @JsonIgnore
     Balance cloneBalance() {

--- a/backend/src/main/java/by/bk/entity/user/UserService.java
+++ b/backend/src/main/java/by/bk/entity/user/UserService.java
@@ -871,7 +871,16 @@ public class UserService implements UserAPI {
                 .set("tags.%s.color".formatted(tagIndex), color)
                 .set("tags.%s.textColor".formatted(tagIndex), textColor)
                 .set("tags.%s.active".formatted(tagIndex), active);
-        return updateUser(query, update);
+        var response = updateUser(query, update);
+
+        // Update tag title in all history items if title changed
+        if (!StringUtils.equals(oldTitle, newTitle)) {
+            Query historyQuery = Query.query(Criteria.where("user").is(login).and("tags").is(oldTitle));
+            Update historyUpdate = new Update().set("tags.$", newTitle);
+            mongoTemplate.updateMulti(historyQuery, historyUpdate, HistoryItem.class);
+        }
+
+        return response;
     }
 
     @Override

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bk",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/frontend/src/app/bk.module.ts
+++ b/frontend/src/app/bk.module.ts
@@ -9,6 +9,7 @@ import { MatCardModule } from '@angular/material/card';
 import { DateAdapter, MAT_DATE_LOCALE } from '@angular/material/core';
 import { MatMomentDateModule, MomentDateAdapter } from '@angular/material-moment-adapter';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
 
 import { JwtModule } from '@auth0/angular-jwt';
 import 'moment/locale/ru';
@@ -97,6 +98,8 @@ import { DeviceMessageDialogComponent } from './settings/devices/device-message-
 import { DeviceMessageAssignDialogComponent } from './history/device-message-assign-dialog/device-message-assign-dialog.component';
 import { TagsComponent } from './settings/tags/tags.component';
 import { TagDialogComponent } from './settings/tags/tag-dialog/tag-dialog.component';
+import { TagChipsComponent } from './common/components/tag/tag-chips/tag-chips.component';
+import { TagSelectorComponent } from './common/components/tag/tag-selector/tag-selector.component';
 import { ToggleComponent } from './common/components/toggle/toggle.component';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -180,8 +183,9 @@ import { PeriodFilterComponent } from './reports/period-filter/period-filter.com
     DeviceMessageAssignDialogComponent,
     TagsComponent,
     TagDialogComponent,
+    TagChipsComponent,
+    TagSelectorComponent,
     ToggleComponent,
-    InputComponent,
     SpinnerComponent
   ],
   bootstrap: [BookkeepingRootComponent],
@@ -207,6 +211,7 @@ import { PeriodFilterComponent } from './reports/period-filter/period-filter.com
     MatMomentDateModule,
     MatCardModule,
     MatTooltipModule,
+    MatAutocompleteModule,
     PeriodFilterComponent
   ],
   providers: [

--- a/frontend/src/app/common/components/tag/tag-chips/tag-chips.component.css
+++ b/frontend/src/app/common/components/tag/tag-chips/tag-chips.component.css
@@ -1,0 +1,11 @@
+.tag-chips {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.tag-chip {
+  font-size: 12px;
+  font-weight: normal;
+  padding: 2px 4px;
+}

--- a/frontend/src/app/common/components/tag/tag-chips/tag-chips.component.html
+++ b/frontend/src/app/common/components/tag/tag-chips/tag-chips.component.html
@@ -1,0 +1,9 @@
+@if (tagTitles && tagTitles.length > 0) {
+  <span class="tag-chips">
+    @for (title of tagTitles; track title) {
+      @if (getTag(title); as tag) {
+        <span class="label tag-chip" [style.background-color]="tag.color" [style.color]="tag.textColor">{{tag.title}}</span>
+      }
+    }
+  </span>
+}

--- a/frontend/src/app/common/components/tag/tag-chips/tag-chips.component.ts
+++ b/frontend/src/app/common/components/tag/tag-chips/tag-chips.component.ts
@@ -1,0 +1,21 @@
+import { Component, Input } from '@angular/core';
+
+import { ProfileService } from '../../../service/profile.service';
+import { Tag } from '../../../model/tag';
+
+@Component({
+    selector: 'bk-tag-chips',
+    templateUrl: './tag-chips.component.html',
+    styleUrls: ['./tag-chips.component.css'],
+    standalone: false
+})
+export class TagChipsComponent {
+  @Input() public tagTitles: string[] = [];
+
+  public constructor(private _profileService: ProfileService) {}
+
+  public getTag(title: string): Tag | undefined {
+    const profileTags = this._profileService.authenticatedProfile?.tags || [];
+    return profileTags.find(tag => tag.title === title);
+  }
+}

--- a/frontend/src/app/common/components/tag/tag-selector/tag-selector.component.css
+++ b/frontend/src/app/common/components/tag/tag-selector/tag-selector.component.css
@@ -1,0 +1,38 @@
+.tag-selector {
+  position: relative;
+}
+
+.selected-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 8px;
+}
+
+.tag-chip {
+  font-size: 12px;
+  font-weight: normal;
+  padding: 2px 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.remove-tag {
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  opacity: 0.7;
+}
+
+.remove-tag:hover {
+  opacity: 1;
+}
+
+.tag-input {
+  width: 100%;
+}
+
+:host ::ng-deep .mat-mdc-option {
+  min-height: 30px;
+}

--- a/frontend/src/app/common/components/tag/tag-selector/tag-selector.component.html
+++ b/frontend/src/app/common/components/tag/tag-selector/tag-selector.component.html
@@ -1,0 +1,27 @@
+<div class="tag-selector">
+  <input
+    type="text"
+    class="form-control tag-input"
+    [formControl]="searchControl"
+    placeholder="Тэг"
+    [matAutocomplete]="auto">
+  <mat-autocomplete #auto="matAutocomplete" class="tag-autocomplete" (optionSelected)="selectTag($event.option.value)">
+    @for (tag of filteredTags; track tag.title) {
+      <mat-option [value]="tag">
+        <span class="label" [style.background-color]="tag.color" [style.color]="tag.textColor">{{tag.title}}</span>
+      </mat-option>
+    }
+  </mat-autocomplete>
+  @if (selectedTags.length > 0) {
+    <div class="selected-tags">
+      @for (title of selectedTags; track title) {
+        @if (getTag(title); as tag) {
+          <span class="label tag-chip" [style.background-color]="tag.color" [style.color]="tag.textColor">
+            {{tag.title}}
+            <span class="remove-tag" (click)="removeTag(title)">&times;</span>
+          </span>
+        }
+      }
+    </div>
+  }
+</div>

--- a/frontend/src/app/common/components/tag/tag-selector/tag-selector.component.ts
+++ b/frontend/src/app/common/components/tag/tag-selector/tag-selector.component.ts
@@ -1,0 +1,61 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { FormControl } from '@angular/forms';
+
+import { ProfileService } from '../../../service/profile.service';
+import { Tag } from '../../../model/tag';
+
+@Component({
+    selector: 'bk-tag-selector',
+    templateUrl: './tag-selector.component.html',
+    styleUrls: ['./tag-selector.component.css'],
+    standalone: false
+})
+export class TagSelectorComponent implements OnInit {
+  @Input() public selectedTags: string[] = [];
+  @Output() public selectedTagsChange = new EventEmitter<string[]>();
+
+  public searchControl = new FormControl('');
+  public filteredTags: Tag[] = [];
+  public allActiveTags: Tag[] = [];
+  public tagsMap: Map<string, Tag> = new Map();
+
+  public constructor(private _profileService: ProfileService) {}
+
+  public ngOnInit(): void {
+    const profileTags = this._profileService.authenticatedProfile?.tags || [];
+    this.allActiveTags = profileTags
+      .filter(tag => tag.active)
+      .sort((a, b) => a.title.localeCompare(b.title, 'ru'));
+    profileTags.forEach(tag => this.tagsMap.set(tag.title, tag));
+
+    this.searchControl.valueChanges.subscribe(() => this.updateFilteredTags());
+    this.updateFilteredTags();
+  }
+
+  public updateFilteredTags(): void {
+    const searchValue = (this.searchControl.value || '').toLowerCase();
+    this.filteredTags = this.allActiveTags.filter(tag =>
+      !this.selectedTags.includes(tag.title) &&
+      tag.title.toLowerCase().includes(searchValue)
+    );
+  }
+
+  public selectTag(tag: Tag): void {
+    if (!this.selectedTags.includes(tag.title)) {
+      this.selectedTags = [...this.selectedTags, tag.title];
+      this.selectedTagsChange.emit(this.selectedTags);
+    }
+    this.searchControl.setValue('');
+    this.updateFilteredTags();
+  }
+
+  public removeTag(title: string): void {
+    this.selectedTags = this.selectedTags.filter(t => t !== title);
+    this.selectedTagsChange.emit(this.selectedTags);
+    this.updateFilteredTags();
+  }
+
+  public getTag(title: string): Tag | undefined {
+    return this.tagsMap.get(title);
+  }
+}

--- a/frontend/src/app/common/model/history/history-type.ts
+++ b/frontend/src/app/common/model/history/history-type.ts
@@ -16,4 +16,5 @@ export interface HistoryType {
   archived: boolean;
   notProcessed?: boolean;
   deviceMessages?: DeviceMessage[];
+  tags?: string[];
 }

--- a/frontend/src/app/history/history-edit-dialog/history-edit-dialog.component.html
+++ b/frontend/src/app/history/history-edit-dialog/history-edit-dialog.component.html
@@ -66,6 +66,11 @@
       <div class="form-row">
         <input type="text" [(ngModel)]="historyItem.description" class="form-control" placeholder="Комментарий">
       </div>
+      @if (isTypeSelected('expense') || isTypeSelected('income')) {
+        <div class="form-row">
+          <bk-tag-selector [(selectedTags)]="historyItem.tags"></bk-tag-selector>
+        </div>
+      }
     </div>
   </div>
   @if (showGoalContainer()) {

--- a/frontend/src/app/history/history-edit-dialog/history-edit-dialog.component.ts
+++ b/frontend/src/app/history/history-edit-dialog/history-edit-dialog.component.ts
@@ -70,6 +70,9 @@ export class HistoryEditDialogComponent implements OnInit {
       this._originalHistoryItem.balance = Object.assign({}, this.data.historyItem.balance);
     }
     this.historyItem = this.data.historyItem || this.initNewHistoryItem('expense', today.getFullYear(), today.getMonth() + 1, today.getDate());
+    if (!this.historyItem.tags) {
+      this.historyItem.tags = [];
+    }
     this.selectedDate = this.toMoment(this.historyItem);
     if (this.data.fromDeviceMessage) {
       this.historyItem.balance.currency = this._profileService.defaultCurrency.name;
@@ -256,7 +259,7 @@ export class HistoryEditDialogComponent implements OnInit {
 
   private initNewHistoryItem(historyType: string, year: number, month: number, day: number, balanceValue?: number, balanceCurrency?: string, balanceNewCurrency?: string,
                              balanceAlternativeCurrency?: {[key: string]: number}, balanceAccount?: string, balanceSubAccount?: string, historyDescription?: string,
-                             archived?: boolean, id?: string, deviceMessages?: DeviceMessage[]): HistoryType {
+                             archived?: boolean, id?: string, deviceMessages?: DeviceMessage[], historyTags?: string[]): HistoryType {
 
     const currencyName: string = balanceCurrency || this._authenticationService.defaultCurrency.name;
     const result: HistoryType = {
@@ -268,6 +271,7 @@ export class HistoryEditDialogComponent implements OnInit {
       'day': day,
       'description': historyDescription,
       'archived': archived,
+      'tags': historyTags || [],
       'balance': {
         'value': balanceValue,
         'account': balanceAccount,
@@ -338,7 +342,8 @@ export class HistoryEditDialogComponent implements OnInit {
   private initNewHistoryItemFromExisting(historyType: string, originalItem: HistoryType): HistoryType {
     const balance: HistoryBalanceType = originalItem.balance;
     return this.initNewHistoryItem(historyType, originalItem.year, originalItem.month, originalItem.day, balance.value, balance.currency, balance.newCurrency,
-      balance.alternativeCurrency, balance.account, balance.subAccount, originalItem.description, originalItem.archived, originalItem.id, originalItem.deviceMessages);
+      balance.alternativeCurrency, balance.account, balance.subAccount, originalItem.description, originalItem.archived, originalItem.id, originalItem.deviceMessages,
+      originalItem.tags);
   }
 
   private validateTransfer(): boolean {

--- a/frontend/src/app/history/history.component.css
+++ b/frontend/src/app/history/history.component.css
@@ -167,3 +167,7 @@ bk-history-page-actions {
     min-width: 95px;
   }
 }
+
+.history-tags {
+  margin-bottom: 2px;
+}

--- a/frontend/src/app/history/history.component.html
+++ b/frontend/src/app/history/history.component.html
@@ -148,7 +148,14 @@
                 <!--expense or income forth column-->
                 @if (historyItem.type === 'expense' || historyItem.type === 'income') {
                   <div class="col-sm-3 description">
-                    <div>{{historyItem.description}}</div>
+                    @if (historyItem.originalItem.tags && historyItem.originalItem.tags.length > 0) {
+                      <div class="history-tags">
+                        <bk-tag-chips [tagTitles]="historyItem.originalItem.tags"></bk-tag-chips>
+                      </div>
+                    }
+                    @if (historyItem.description) {
+                      <div>{{historyItem.description}}</div>
+                    }
                     @if (historyItem.showDeviceMessageIndex != null) {
                       <div class="footnote" [innerHTML]="getFormattedDeviceMessage(historyItem.deviceMessages[historyItem.showDeviceMessageIndex].fullText)"></div>
                     }


### PR DESCRIPTION
- Add tags field to HistoryItem entity (backend) and HistoryType interface (frontend)
- Create TagChipsComponent for read-only tag display with colors
- Create TagSelectorComponent with autocomplete for tag selection
- Integrate tag selector in history add/edit dialog (expense/income only)
- Display tags in history list with colored chips
- Update tag titles in history items when tag is renamed
- Bump version to 3.4.1