### PR TITLE
Send debug push notifications directly from PushListenerService

### DIFF
--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -13,7 +13,7 @@ android {
         applicationId "by.bk.bookkeeper.android"
         minSdkVersion 28
         targetSdkVersion 35
-        versionCode 29
+        versionCode 30
         versionName "2.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/mobile/app/src/main/java/by/bk/bookkeeper/android/push/PushListenerService.kt
+++ b/mobile/app/src/main/java/by/bk/bookkeeper/android/push/PushListenerService.kt
@@ -1,7 +1,6 @@
 package by.bk.bookkeeper.android.push
 
 import android.app.Notification
-import android.content.Intent
 import android.os.Handler
 import android.os.Looper
 import android.service.notification.NotificationListenerService
@@ -13,6 +12,8 @@ import androidx.work.WorkManager
 import by.bk.bookkeeper.android.Injection
 import by.bk.bookkeeper.android.sms.preferences.SharedPreferencesProvider
 import by.bk.bookkeeper.android.sms.worker.PendingPushWorker
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.schedulers.Schedulers
 import timber.log.Timber
 
 /**
@@ -36,6 +37,9 @@ class PushListenerService : NotificationListenerService() {
     private val recentNotifications = mutableSetOf<String>()
     private val cleanupThreshold = 100 // Clean up after this many notifications
     private val pushProcessor by lazy { Injection.providePushProcessor() }
+    private val repository by lazy { Injection.provideMessagesRepository() }
+    private val gson by lazy { com.google.gson.Gson() }
+    private val disposables = CompositeDisposable()
 
     override fun onNotificationPosted(sbn: StatusBarNotification) {
         super.onNotificationPosted(sbn)
@@ -69,12 +73,9 @@ class PushListenerService : NotificationListenerService() {
             sbn.postTime
         )
 
-        // Send debug broadcast if enabled
+        // Send debug log directly to server if enabled
         if (SharedPreferencesProvider.getDebugPushNotifications()) {
-            sendBroadcast(Intent(ACTION_DEBUG_NOTIFICATION_POSTED).apply {
-                setPackage(packageName)
-                putExtra(PUSH_MESSAGE, pushMessage)
-            })
+            sendDebugLog(pushMessage)
         }
 
         // Process push with configured delay to allow SMS priority
@@ -122,12 +123,36 @@ class PushListenerService : NotificationListenerService() {
 
     override fun onDestroy() {
         handler.removeCallbacksAndMessages(null) // Clean up pending callbacks
+        disposables.clear()
         super.onDestroy()
     }
 
-    companion object {
-        const val PUSH_MESSAGE = "PUSH_MESSAGE"
-        const val ACTION_DEBUG_NOTIFICATION_POSTED = "debug_notification_posted"
+    private fun sendDebugLog(pushMessage: PushMessage) {
+        val formattedTimestamp = java.text.SimpleDateFormat(
+            "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+            java.util.Locale.US
+        ).apply {
+            timeZone = java.util.TimeZone.getTimeZone("UTC")
+        }.format(java.util.Date(pushMessage.timestamp))
+
+        val debugData = mapOf(
+            "type" to "push_notification",
+            "timestamp" to formattedTimestamp,
+            "packageName" to pushMessage.packageName,
+            "text" to pushMessage.text,
+            "postTime" to pushMessage.timestamp
+        )
+
+        val debugJson = gson.toJson(debugData)
+
+        disposables.add(
+            repository.sendLog(debugJson)
+                .subscribeOn(Schedulers.io())
+                .subscribe(
+                    { Timber.d("Debug push log sent successfully") },
+                    { e -> Timber.e(e, "Failed to send debug push log") }
+                )
+        )
     }
 
 }

--- a/mobile/app/src/main/java/by/bk/bookkeeper/processor/ProcessingService.kt
+++ b/mobile/app/src/main/java/by/bk/bookkeeper/processor/ProcessingService.kt
@@ -7,19 +7,13 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.content.IntentFilter
 import android.content.pm.PackageManager
-import android.os.Build
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
-import by.bk.bookkeeper.android.Injection
 import by.bk.bookkeeper.android.R
-import by.bk.bookkeeper.android.push.PushListenerService
-import by.bk.bookkeeper.android.push.PushMessage
 import by.bk.bookkeeper.android.sms.preferences.SharedPreferencesProvider
 import by.bk.bookkeeper.android.sms.worker.PeriodicMessagesScheduler
 import by.bk.bookkeeper.android.ui.home.AccountingActivity
@@ -41,18 +35,14 @@ import timber.log.Timber
  * This service now only handles:
  * - Scheduling PeriodicMessagesScheduler on boot/app open
  * - Displaying notification with pending/unprocessed message count
- * - Debug logging for push notifications
  */
 class ProcessingService : Service() {
 
-    private lateinit var debugReceiver: DebugBroadcastReceiver
     // CRITICAL: Use lazy initialization to avoid blocking onCreate().
     // The 5-second foreground service deadline starts when startForegroundService() is called.
     // If property initializers (especially network stack creation) take too long,
     // onCreate() won't be reached in time to call startForeground().
-    private val repository by lazy { Injection.provideMessagesRepository() }
     private val disposables = CompositeDisposable()
-    private val gson by lazy { com.google.gson.Gson() }
 
     // State for notification content (updated from any thread, read only from main thread)
     @Volatile private var pendingSmsCount: Int = 0
@@ -80,17 +70,6 @@ class ProcessingService : Service() {
         PeriodicMessagesScheduler.schedule(context = this)
         observePendingMessages()
         observeUnprocessedSms()
-
-        // Register debug broadcast receiver for push notification logging
-        debugReceiver = DebugBroadcastReceiver()
-        val debugFilter = IntentFilter().apply {
-            addAction(PushListenerService.ACTION_DEBUG_NOTIFICATION_POSTED)
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            registerReceiver(debugReceiver, debugFilter, Context.RECEIVER_NOT_EXPORTED)
-        } else {
-            registerReceiver(debugReceiver, debugFilter)
-        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -280,53 +259,10 @@ class ProcessingService : Service() {
     override fun onDestroy() {
         super.onDestroy()
         mainHandler.removeCallbacks(stopWhenIdleRunnable)
-        unregisterReceiver(debugReceiver)
         disposables.clear()
     }
 
     override fun onBind(intent: Intent): IBinder? = null
-
-    inner class DebugBroadcastReceiver : BroadcastReceiver() {
-
-        override fun onReceive(context: Context?, intent: Intent?) {
-            if (intent?.action == PushListenerService.ACTION_DEBUG_NOTIFICATION_POSTED) {
-                val pushMessage = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    intent.getParcelableExtra(PushListenerService.PUSH_MESSAGE, PushMessage::class.java)
-                } else {
-                    @Suppress("DEPRECATION")
-                    intent.getParcelableExtra(PushListenerService.PUSH_MESSAGE)
-                }
-
-                pushMessage?.let { push ->
-                    val formattedTimestamp = java.text.SimpleDateFormat(
-                        "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-                        java.util.Locale.US
-                    ).apply {
-                        timeZone = java.util.TimeZone.getTimeZone("UTC")
-                    }.format(java.util.Date(push.timestamp))
-
-                    val debugData = mapOf(
-                        "type" to "push_notification",
-                        "timestamp" to formattedTimestamp,
-                        "packageName" to push.packageName,
-                        "text" to push.text,
-                        "postTime" to push.timestamp
-                    )
-
-                    val debugJson = gson.toJson(debugData)
-
-                    disposables.add(
-                        repository.sendLog(debugJson)
-                            .subscribeOn(Schedulers.io())
-                            .subscribe(
-                                { Timber.d("Debug log sent successfully") },
-                                { e -> Timber.e(e, "Failed to send debug log") }
-                            )
-                    )
-                }
-            }
-        }
-    }
 
     companion object {
         private const val SERVICE_NOTIFICATION_ID = 1209


### PR DESCRIPTION
Previously debug logs were sent via broadcast to ProcessingService, which auto-stops after 5s of idle. Logs were lost when the app wasn't open. Now debug logs are sent directly from PushListenerService (which is always alive as a NotificationListenerService) to the backend, ensuring they reach the server regardless of ProcessingService state.