### PR TITLE
Suppress TLS-probe noise from Tomcat HTTP11Processor logs

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -13,6 +13,7 @@ bookkeeper.host=https://deplake.tk
 #spring.data.mongodb.uri=mongodb://localhost:27017/bookkeeper
 #logging.level.org.springframework.data.mongodb.core.MongoTemplate=DEBUG
 #logging.level.org.springframework.data.mongodb.repository.Query=DEBUG
+logging.level.org.apache.coyote.http11.Http11Processor=WARN
 
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587


### PR DESCRIPTION
Set logging level for org.apache.coyote.http11.Http11Processor to WARN to suppress repeated 'Error parsing HTTP request header' messages from port 8080 HTTPS probes (TLS ClientHello). Tomcat correctly rejects these connections; we just reduce log noise.