### PR TITLE
Fix summary report totals calculation bug and bump to v3.5.2

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>by.bk</groupId>
     <artifactId>bookkeeper-backend</artifactId>
-    <version>3.5.1</version>
+    <version>3.5.2</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bk",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/frontend/src/app/reports/report-summary/report-summary.component.ts
+++ b/frontend/src/app/reports/report-summary/report-summary.component.ts
@@ -139,7 +139,7 @@ export class ReportSummaryComponent extends BaseReport implements OnInit, OnDest
         items.map(item => item.values).forEach((valueMap: {[currency: string]: number}) => {
           Object.keys(valueMap).forEach(currency => {
             this.reportSum = this.reportSum + this.convertValue(valueMap[currency], currency, this.reportCurrency);
-            this.totals[currency] = valueMap[currency] + (this.totals[currency] | 0);
+            this.totals[currency] = valueMap[currency] + (this.totals[currency] || 0);
           });
         });
 


### PR DESCRIPTION
- Change bitwise OR (| 0) to logical OR (|| 0) on line 142 of report-summary.component.ts
- Bitwise OR was truncating decimal portions of accumulated totals on each iteration
- Logical OR preserves decimal precision while still defaulting to 0 for undefined values
- Fixes issue where category sums didn't match the reported total